### PR TITLE
Reduce max framerate of bgParticles 120->24

### DIFF
--- a/src/components/Background/Config/particles-config.js
+++ b/src/components/Background/Config/particles-config.js
@@ -1,6 +1,6 @@
 const particlesConfig = {
     background: "transparent",
-    fpsLimit: 120,
+    fpsLimit: 24,
     interactivity: {
         events: {
             onClick: {


### PR DESCRIPTION
Should reduce the scripting time and be easier on mobile devices while keeping the visual impact.